### PR TITLE
fix: Skip brew audit in bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -62,7 +62,7 @@ jobs:
             esac
             echo "Bumping $FULL_PKG_NAME to $LATEST_VERSION (brew $BUMP_CMD)"
             ret=0
-            output=$(brew "$BUMP_CMD" "$FULL_PKG_NAME" --no-browse --no-fork --version "$LATEST_VERSION" 2>&1) || ret=$?
+            output=$(brew "$BUMP_CMD" "$FULL_PKG_NAME" --no-browse --no-fork --no-audit --version "$LATEST_VERSION" 2>&1) || ret=$?
             echo "$output"
             if [ "$ret" -ne 0 ]; then
               echo "Error: Failed to bump $FULL_PKG_NAME"


### PR DESCRIPTION
## 問題

#18 のマージ後、bumpワークフローの `brew bump-cask-pr` が最終段の `brew audit` で失敗する。

```
Error: The binary URL https://api.github.com/repos/horaguy/aseprite-build/releases/assets/510912340 is not reachable (HTTP status code 404)
Error: exception while auditing aseprite: ... /usr/bin/env: 'plutil': No such file or directory
```

## 原因

どちらもaudit特有の問題で、このtapの構成ではLinux CI上のauditは構造的に通らない:

- auditのURL到達性チェックはcaskの `header:`(認証)を付けずにアクセスするため、privateアセットは必ず404になる
- auditは.appを展開して `Info.plist` を `plutil` で検証するが、`plutil` はmacOS専用ツールでLinuxランナーに存在しない

バージョン更新・ダウンロード・sha256計算までは正常に完了している。

## 修正

`brew bump-*-pr` に `--no-audit` を追加。`brew style`(rubocop)は環境非依存なので引き続き実行される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)