### PR TITLE
revert: Push bump PRs with GITHUB_TOKEN; add depends_on :macos

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For gh-cli
+      HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For 'brew bump-*-pr'
     steps:
       - uses: actions/checkout@v6
       - name: Configure Git name and email
@@ -29,10 +30,8 @@ jobs:
           client-id: ${{ secrets.GITHUBAPP_ID }}
           private-key: ${{ secrets.GITHUBAPP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - name: Set HOMEBREW_GITHUB_API_TOKEN and HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN
-        run: |
-          echo "HOMEBREW_GITHUB_API_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
-          echo "HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
+      - name: Set HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN
+        run: echo "HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
       - name: Install Homebrew (it's not installed in ubuntu-slim)
         run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       - uses: Homebrew/actions/setup-homebrew@main
@@ -46,7 +45,7 @@ jobs:
           shopt -s nullglob
           for rb in Casks/*.rb Formula/*.rb; do
             FULL_PKG_NAME="${TAP_NAME}/$(basename "$rb" .rb)"
-            LATEST_VERSION=$(brew livecheck --quiet --json --newer-only "$FULL_PKG_NAME" | jq -r '.[0].version.latest // empty')
+            LATEST_VERSION=$(HOMEBREW_GITHUB_API_TOKEN=$HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN brew livecheck --quiet --json --newer-only "$FULL_PKG_NAME" | jq -r '.[0].version.latest // empty')
             if [ -z "$LATEST_VERSION" ]; then
               echo "Skip: $FULL_PKG_NAME is already up to date (or livecheck is skipped)"
               continue

--- a/Casks/aseprite.rb
+++ b/Casks/aseprite.rb
@@ -27,6 +27,8 @@ cask "aseprite" do
     end
   end
 
+  depends_on :macos
+
   app "Aseprite.app"
 
   postflight do


### PR DESCRIPTION
## 背景

App Tokenに統一した構成では、bumpブランチのpushが `Permission to horaguy/homebrew-tap.git denied to horaguy[bot]` で403になった。GitHub Appにはtapへの書き込み権限を持たせない方針としたため、以前の分離型に戻す。

## 変更内容

- **bump.yml**: トークンの役割を分離した形に戻す
  - job levelに `HOMEBREW_GITHUB_API_TOKEN: secrets.GITHUB_TOKEN` を復活(`brew bump-*-pr` のpush・PR作成用)
  - App Tokenは `HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN` として設定(privateアセットのダウンロード用)
  - ループ内のlivecheckのみ `HOMEBREW_GITHUB_API_TOKEN=$HOMEBREW_PRIVATE_TAP_GITHUB_TOKEN` をインライン前置(privateリポジトリの読み取り用)
- **Casks/aseprite.rb**: `depends_on :macos` を追加(bump実行時に `brew style` が自動補正していた Homebrew/OSDependsOn を先取りして適用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)