### PR TITLE
style: Fix all brew style offenses in casks

### DIFF
--- a/Casks/huion-k20.rb
+++ b/Casks/huion-k20.rb
@@ -11,6 +11,8 @@ cask "huion-k20" do
     skip "It's difficult to get the latest version, and the last update was in 2023. So, we skip livecheck."
   end
 
+  depends_on :macos
+
   app "HuionTablet.app"
 
   uninstall launchctl: "com.huion.HuionTablet",

--- a/Casks/melodyne.rb
+++ b/Casks/melodyne.rb
@@ -12,12 +12,14 @@ cask "melodyne" do
     regex(/Melodyne\.(\d+(?:\.\d+)*)-Demo\.dmg/)
   end
 
+  depends_on :macos
+
   pkg "Melodyne.#{version}.pkg"
 
   uninstall launchctl: "com.celemony.melodyne",
             quit:      "com.celemony.melodyne",
             script:    {
               executable: "/Applications/Melodyne 5/Melodyne Uninstaller.app/Contents/MacOS/Melodyne Uninstaller",
-              sudo:      true,
+              sudo:       true,
             }
 end

--- a/Casks/moho.rb
+++ b/Casks/moho.rb
@@ -2,16 +2,19 @@ cask "moho" do
   version "14.4"
   sha256 "abd8dd9f87c8cb1ef5fce90d393c4f7730e4c53cdfa404bef15f015c7e3e65c6"
 
-  # Mirror Link (primary link is https://delivery.shopifyapps.com/-/b1b5e7614552eeac/15449ea520c87e08 but it's not work with CLI)
+  # Mirror Link (primary link is https://delivery.shopifyapps.com/-/b1b5e7614552eeac/15449ea520c87e08
+  # but it's not work with CLI)
   url "https://dl.dropboxusercontent.com/scl/fi/nrz0dcufujy6093mk4g2h/Moho1440_Mac.dmg?rlkey=wo8ug7lalxmjfzdmcgzrh0gyl&st=q83hblkk"
   name "MOHO"
   desc "Vector based 2D Computer animation software"
-  homepage "https://moho.lostmarble.com"
+  homepage "https://moho.lostmarble.com/"
 
   livecheck do
     url "https://moho.lostmarble.com/pages/download"
     regex(/Current installer version - Moho (\d+(?:\.\d+)*)/i)
   end
+
+  depends_on :macos
 
   app "Moho.app"
 


### PR DESCRIPTION
`brew style horaguy/tap` で警告されていた6件をすべて解消します(修正後は `6 files inspected, no offenses detected` を確認済み)。

- **huion-k20 / melodyne / moho**: `depends_on :macos` を追加(Homebrew/OSDependsOn。asepriteは #21 で対応済み)
- **melodyne**: `uninstall` の `script:` ハッシュ内 `sudo:` の値の位置を揃える(Layout/HashAlignment)
- **moho**: `homepage` 末尾にスラッシュを追加(Cask/HomepageUrlStyling)
- **moho**: ミラーリンクのコメントが118桁制限を超えていたため2行に折り返し(Layout/LineLength)

いずれも `brew style --fix` の自動補正結果をそのまま採用しています(コメント折り返しのみ手動)。

なお `brew style` はワークフローファイルにも指摘を出しますが(bump.ymlの `client-id` に対するactionlintの指摘は、actionlint内蔵の古いアクション定義による誤検知で実際のCIは動作済み。ほかにshellcheckのSC2086が数件)、今回のPRはご依頼のスコープであるcaskのみを対象としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)